### PR TITLE
fix(popover): fix CdkTrapFocus issue #48

### DIFF
--- a/projects/material-extended/mde/src/lib/popover/popover-module.ts
+++ b/projects/material-extended/mde/src/lib/popover/popover-module.ts
@@ -6,11 +6,13 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { MdePopover } from './popover';
 import { MdePopoverTrigger } from './popover-trigger';
 import { MdePopoverTarget } from './popover-target';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
   imports: [
     OverlayModule,
-    CommonModule
+    CommonModule,
+    A11yModule
   ],
   exports: [MdePopover, MdePopoverTrigger, MdePopoverTarget],
   declarations: [MdePopover, MdePopoverTrigger, MdePopoverTarget],

--- a/projects/material-extended/mde/src/lib/popover/popover.html
+++ b/projects/material-extended/mde/src/lib/popover/popover.html
@@ -4,7 +4,7 @@
        (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" [@.disabled]="disableAnimation"
        [@transformPopover]="'enter'">
     <div class="mde-popover-direction-arrow" [ngStyle]="popoverArrowStyles" *ngIf="!overlapTrigger"></div>
-    <div class="mde-popover-content" [ngStyle]="popoverContentStyles" cdkTrapFocus="focusTrapEnabled" cdkTrapFocusAutoCapture="true">
+    <div class="mde-popover-content" [ngStyle]="popoverContentStyles" [cdkTrapFocus]="focusTrapEnabled" cdkTrapFocusAutoCapture="true">
       <ng-content></ng-content>
     </div>
   </div>

--- a/projects/material-extended/mde/src/lib/popover/popover.html
+++ b/projects/material-extended/mde/src/lib/popover/popover.html
@@ -4,7 +4,7 @@
        (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" [@.disabled]="disableAnimation"
        [@transformPopover]="'enter'">
     <div class="mde-popover-direction-arrow" [ngStyle]="popoverArrowStyles" *ngIf="!overlapTrigger"></div>
-    <div class="mde-popover-content" [ngStyle]="popoverContentStyles" cdkTrapFocus="focusTrapEnabled">
+    <div class="mde-popover-content" [ngStyle]="popoverContentStyles" cdkTrapFocus="focusTrapEnabled" cdkTrapFocusAutoCapture="true">
       <ng-content></ng-content>
     </div>
   </div>


### PR DESCRIPTION
I have imported the 'A11yModule' module in the package. It was missing. Which caused cdkTrapFocus not to work.